### PR TITLE
Fix small typo (Whiteborad > Whiteboard) in german translation

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -19,7 +19,7 @@ title#:#Titel
 description#:#Beschreibung
 default_permissions#:#Standardberechtigungen
 all_write#:#Alle Benutzer können das Whiteboard ansehen und bearbeiten
-all_read#:#Nur Kurs- bzw Gruppenadministratoren können das Whiteborad bearbeiten, alle anderen Benutzer können das Whiteboard nur ansehen, aber nicht bearbeiten
+all_read#:#Nur Kurs- bzw Gruppenadministratoren können das Whiteboard bearbeiten, alle anderen Benutzer können das Whiteboard nur ansehen, aber nicht bearbeiten
 online#:#Online
 save#:#Speichern
 update#:#Update


### PR DESCRIPTION
Noticed a typo.

![borat](https://github.com/user-attachments/assets/83fa8692-44ff-4a57-a040-e605973f0e0f)
( Close enough :yum: )