### PR TITLE
Add _getIcon method for proper icon display

### DIFF
--- a/classes/class.ilWhiteboardPlugin.php
+++ b/classes/class.ilWhiteboardPlugin.php
@@ -42,4 +42,12 @@ class ilWhiteboardPlugin extends ilRepositoryObjectPlugin
         return true;
     }
 
+    /**
+     * Get the title icon
+     */
+    public static function _getIcon(string $a_type): string
+    {
+        return 'Customizing/global/plugins/Services/Repository/RepositoryObject/Whiteboard/templates/images/icon_xswb.svg';
+    }
+
 }


### PR DESCRIPTION
This pull request introduces a new static method to the `ilWhiteboardPlugin` class to provide a custom icon for the plugin.

Enhancement to plugin icon handling:

* Added the static method `_getIcon` to `ilWhiteboardPlugin`, which returns the path to a custom SVG icon for the whiteboard plugin.